### PR TITLE
fix(encoder): 値が飛ぶバグを修正

### DIFF
--- a/tim/encoder.cpp
+++ b/tim/encoder.cpp
@@ -38,13 +38,10 @@ void Encoder::update() noexcept {
     lastRawCount = rawCount;
     rawCount = __HAL_TIM_GET_COUNTER(htim);
     count += rawCount - lastRawCount;
-    if (__HAL_TIM_GET_FLAG(htim, TIM_FLAG_UPDATE)) {
-        __HAL_TIM_CLEAR_FLAG(htim, TIM_FLAG_UPDATE);
-        if (((int32_t) (lastRawCount - rawCount)) > ((int32_t) (__HAL_TIM_GET_AUTORELOAD(htim) / 2))) { // overflow
-            count += __HAL_TIM_GET_AUTORELOAD(htim);
-        } else if (((int32_t) (rawCount - lastRawCount)) > ((int32_t) (__HAL_TIM_GET_AUTORELOAD(htim) / 2))) { // underflow
-            count -= __HAL_TIM_GET_AUTORELOAD(htim);
-        }
+    if (((int32_t) (lastRawCount - rawCount)) > ((int32_t) (__HAL_TIM_GET_AUTORELOAD(htim) / 2))) { // overflow
+        count += __HAL_TIM_GET_AUTORELOAD(htim);
+    } else if (((int32_t) (rawCount - lastRawCount)) > ((int32_t) (__HAL_TIM_GET_AUTORELOAD(htim) / 2))) { // underflow
+        count -= __HAL_TIM_GET_AUTORELOAD(htim);
     }
 }
 

--- a/tim/encoder.cpp
+++ b/tim/encoder.cpp
@@ -40,8 +40,11 @@ void Encoder::update() noexcept {
     count += rawCount - lastRawCount;
     if (__HAL_TIM_GET_FLAG(htim, TIM_FLAG_UPDATE)) {
         __HAL_TIM_CLEAR_FLAG(htim, TIM_FLAG_UPDATE);
-        // FLAGが立った時、counter period の倍数を今回値から引いて、修正する
-        count -= __HAL_TIM_GET_AUTORELOAD(htim) * std::round((float)(rawCount - lastRawCount)/__HAL_TIM_GET_AUTORELOAD(htim));
+        if ((int32_t)(rawCount - lastRawCount) < (int32_t) - __HAL_TIM_GET_AUTORELOAD(htim) / 2) {
+            count += __HAL_TIM_GET_AUTORELOAD(htim);
+        } else if ((int32_t)(rawCount - lastRawCount) > (int32_t) + __HAL_TIM_GET_AUTORELOAD(htim) / 2) {
+            count -= __HAL_TIM_GET_AUTORELOAD(htim);
+        }
     }
 }
 

--- a/tim/encoder.cpp
+++ b/tim/encoder.cpp
@@ -1,7 +1,6 @@
 #ifndef CONFIG_DISABLE_MODULE_TIM
 
 #include "tim/encoder.hpp"
-#include <cmath>
 
 namespace halex {
 

--- a/tim/encoder.cpp
+++ b/tim/encoder.cpp
@@ -40,9 +40,9 @@ void Encoder::update() noexcept {
     count += rawCount - lastRawCount;
     if (__HAL_TIM_GET_FLAG(htim, TIM_FLAG_UPDATE)) {
         __HAL_TIM_CLEAR_FLAG(htim, TIM_FLAG_UPDATE);
-        if ((int32_t)(rawCount - lastRawCount) < (int32_t) - __HAL_TIM_GET_AUTORELOAD(htim) / 2) {
+        if (((int32_t) (lastRawCount - rawCount)) > ((int32_t) (__HAL_TIM_GET_AUTORELOAD(htim) / 2))) { // overflow
             count += __HAL_TIM_GET_AUTORELOAD(htim);
-        } else if ((int32_t)(rawCount - lastRawCount) > (int32_t) + __HAL_TIM_GET_AUTORELOAD(htim) / 2) {
+        } else if (((int32_t) (rawCount - lastRawCount)) > ((int32_t) (__HAL_TIM_GET_AUTORELOAD(htim) / 2))) { // underflow
             count -= __HAL_TIM_GET_AUTORELOAD(htim);
         }
     }

--- a/tim/encoder.cpp
+++ b/tim/encoder.cpp
@@ -1,6 +1,7 @@
 #ifndef CONFIG_DISABLE_MODULE_TIM
 
 #include "tim/encoder.hpp"
+#include <cmath>
 
 namespace halex {
 
@@ -39,11 +40,8 @@ void Encoder::update() noexcept {
     count += rawCount - lastRawCount;
     if (__HAL_TIM_GET_FLAG(htim, TIM_FLAG_UPDATE)) {
         __HAL_TIM_CLEAR_FLAG(htim, TIM_FLAG_UPDATE);
-        if (__HAL_TIM_IS_TIM_COUNTING_DOWN(htim)) {
-            count -= __HAL_TIM_GET_AUTORELOAD(htim);
-        } else {
-            count += __HAL_TIM_GET_AUTORELOAD(htim);
-        }
+        // FLAGが立った時、counter period の倍数を今回値から引いて、修正する
+        count -= __HAL_TIM_GET_AUTORELOAD(htim) * std::round((float)(rawCount - lastRawCount)/__HAL_TIM_GET_AUTORELOAD(htim));
     }
 }
 


### PR DESCRIPTION
値が counter period 分、飛ぶバグを修正しました。
（原因は1周期の間に複数回TIM_FLAGが立っていたときに、それを感知できなかったことだと思われます。）