### PR TITLE
feat: CONFIG_DISABLE_IWDG_CONSTEXPR を削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,5 @@ IncludePath: HAL_Extension/ # フォルダ直下
 - [IWDG](iwdg/README.md)
   - [コンフィグ](iwdg/README.md#コンフィグ)
     - [CONFIG_DISABLE_MODULE_IWDG](iwdg/README.md#config_disable_module_iwdg)
-    - [CONFIG_DISABLE_IWDG_CONSTEXPR](iwdg/README.md#config_disable_iwdg_constexpr)
   - [クラス](iwdg/README.md#クラス)
     - [IWDG_Manager](iwdg/class/IWDG_Manager.md)

--- a/iwdg/README.md
+++ b/iwdg/README.md
@@ -6,9 +6,6 @@
 > WDG モジュールの無効化  
 > 定義することでコンパイルされなくなります
 
-> #### CONFIG_DISABLE_IWDG_CONSTEXPR
-> 定義することでコンパイル時に計算を行わなくなります
-
 ## クラス
 - [IWDG_Manager](class/IWDG_Manager.md)
   - [CubeMX](class/IWDG_Manager.md#cubemx)

--- a/iwdg/iwdg_manager.hpp
+++ b/iwdg/iwdg_manager.hpp
@@ -28,11 +28,7 @@ private:
         uint32_t reloadCount;
     };
 
-#ifndef CONFIG_DISABLE_IWDG_CONSTEXPR
     static constexpr std::array<Prescaler, 7> prescalers = {
-#else
-    std::array<Prescaler, 7> prescalers = {
-#endif
         Prescaler{4, IWDG_PRESCALER_4},
         Prescaler{8, IWDG_PRESCALER_8},
         Prescaler{16, IWDG_PRESCALER_16},
@@ -42,11 +38,7 @@ private:
         Prescaler{256, IWDG_PRESCALER_256}
     };
 
-#ifndef CONFIG_DISABLE_IWDG_CONSTEXPR
     static constexpr InitOption getInitOption(
-#else
-    InitOption getInitOption(
-#endif
         float timeOut,
         TimeUnit timeUnit
     ) {
@@ -71,11 +63,7 @@ public:
     static constexpr float minTimeOut = 4 / static_cast<float>(LSI_VALUE);
     static constexpr float maxTimeOut = 256 * 4095 / static_cast<float>(LSI_VALUE);
 
-#ifndef CONFIG_DISABLE_IWDG_CONSTEXPR
     constexpr IWDG_Manager(
-#else
-    IWDG_Manager(
-#endif
         float timeOut,
         TimeUnit timeUnit
     ):
@@ -84,19 +72,11 @@ public:
 
     }
 
-#ifndef CONFIG_DISABLE_IWDG_CONSTEXPR
     constexpr bool available() {
-#else
-    bool available() {
-#endif
         return initOption.prescaler.value != 0;
     }
 
-#ifndef CONFIG_DISABLE_IWDG_CONSTEXPR
     constexpr void init() {
-#else
-    void init() {
-#endif
         if (available()) {
             hiwdg.Init.Prescaler = initOption.prescaler.export_constant;
             hiwdg.Init.Reload = initOption.reloadCount;
@@ -104,11 +84,7 @@ public:
         }
     }
 
-#ifndef CONFIG_DISABLE_IWDG_CONSTEXPR
     constexpr void refresh() {
-#else
-    void refresh() {
-#endif
         if (available()) {
             HAL_IWDG_Refresh(&hiwdg);
         }


### PR DESCRIPTION
# 背景
- CONFIG_DISABLE_IWDG_CONSTEXPR を指定することで、constexpr の定義が外れてコンパイル時計算を行わなくしていた
- constexpr の制限緩和が C++14 でされたので、C++11 の環境でも動くようにさせるためのものであると考えられる。
  ref: https://cpprefjp.github.io/lang/cpp14/relaxing_constraints_on_constexpr.html

# 方針
- v7.0.0 で対応バージョンが C++17 になるので constexpr を必ずつけるようにする