### PR TITLE
feat: コールバック関数を自動で定義されるのではなく、ユーザが runXXXCallback 関数を呼び出すことで実行されるようにした

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,6 @@ IncludePath: HAL_Extension/ # フォルダ直下
 ```
 
 ## 目次
-- [General](general/README.md)
-  - [コンフィグ](general/README.md#コンフィグ)
-    - [CONFIG_DISABLE_EX_CALLBACK](general/README.md#config_disable_ex_callback)
 - [Util](util/README.md)
   - [関数](util/README.md#関数)
     - [std::map](util/function/map.md)
@@ -41,7 +38,6 @@ IncludePath: HAL_Extension/ # フォルダ直下
 - [UART](uart/README.md)
   - [コンフィグ](uart/README.md#コンフィグ)
     - [CONFIG_DISABLE_MODULE_UART](uart/README.md#CONFIG_DISABLE_MODULE_UART)
-    - [CONFIG_USE_HALF_CALLBACK_UART](uart/README.md#CONFIG_USE_HALF_CALLBACK_UART)
   - [関数](uart/README.md#関数)
     - [Transmit](uart/function/README.md#transmit)
     - [Receive](uart/function/README.md#receive)
@@ -81,7 +77,6 @@ IncludePath: HAL_Extension/ # フォルダ直下
 - [ADC](adc/README.md)
   - [コンフィグ](adc/README.md#コンフィグ)
     - [CONFIG_DISABLE_MODULE_ADC](adc/README.md#config_disable_module_adc)
-    - [CONFIG_USE_HALF_CALLBACK_ADC](adc/README.md#config_use_half_callback_adc)
   - [関数](adc/README.md#関数)
     - [setADCCallback](adc/function/README.md#setadccallback)
   - [クラス](adc/README.md#クラス)

--- a/adc/README.md
+++ b/adc/README.md
@@ -6,9 +6,6 @@
 > ADC モジュールの無効化  
 > 定義することでコンパイルされなくなります
 
-##### CONFIG_USE_HALF_CALLBACK_ADC
-> ADCのコールバック関数をハーフに変更します
-
 ## 関数
 - [setADCCallback](function/README.md#setadccallback)
 

--- a/adc/adc_dma.cpp
+++ b/adc/adc_dma.cpp
@@ -34,11 +34,9 @@ uint8_t ADC_DMA::get8(uint8_t index) const noexcept {
     return (uint8_t)(get(index) >> 4);
 }
 
-#ifndef CONFIG_DISABLE_EX_CALLBACK
 void ADC_DMA::setCallback(std::function<void()> function) noexcept {
     setADCCallback(hadc, function);
 }
-#endif // CONFIG_DISABLE_EX_CALLBACK
 
 } // namespace halex
 

--- a/adc/adc_dma.hpp
+++ b/adc/adc_dma.hpp
@@ -22,10 +22,7 @@ public:
     void stop() noexcept;
     uint32_t get(uint8_t index) const noexcept;
     uint8_t get8(uint8_t index) const noexcept;
-
-#ifndef CONFIG_DISABLE_EX_CALLBACK
     void setCallback(std::function<void()> function) noexcept;
-#endif // CONFIG_DISABLE_EX_CALLBACK
 };
 
 } // namespace halex

--- a/adc/callback.cpp
+++ b/adc/callback.cpp
@@ -1,7 +1,5 @@
 #ifndef CONFIG_DISABLE_MODULE_ADC
 
-#ifndef CONFIG_DISABLE_EX_CALLBACK
-
 #include "adc/callback.hpp"
 #include <map>
 #include "util/function.hpp"
@@ -20,18 +18,16 @@ void setADCCallback(ADC_HandleTypeDef &hadc, std::function<void()> function) noe
     setADCCallback(&hadc, function);
 }
 
-} // namespace halex
-
-#ifdef CONFIG_USE_HALF_CALLBACK_ADC
-void HAL_ADC_ConvHalfCpltCallback(ADC_HandleTypeDef* hadc) {
-#else  // CONFIG_USE_HALF_CALLBACK_ADC
-void HAL_ADC_ConvCpltCallback(ADC_HandleTypeDef* hadc) {
-#endif // CONFIG_USE_HALF_CALLBACK_ADC
+void runADCCallback(ADC_HandleTypeDef *hadc) noexcept {
     if(halex::map_contains(halex::adc_callback, hadc)) {
         halex::adc_callback[hadc]();
     }
 }
 
-#endif // CONFIG_DISABLE_EX_CALLBACK
+void runADCCallback(ADC_HandleTypeDef &hadc) noexcept {
+    runADCCallback(&hadc);
+}
+
+} // namespace halex
 
 #endif // CONFIG_DISABLE_MODULE_ADC

--- a/adc/callback.hpp
+++ b/adc/callback.hpp
@@ -3,8 +3,6 @@
 
 #ifndef CONFIG_DISABLE_MODULE_ADC
 
-#ifndef CONFIG_DISABLE_EX_CALLBACK
-
 #include <functional>
 #include "adc.h"
 
@@ -12,10 +10,10 @@ namespace halex {
 
 void setADCCallback(ADC_HandleTypeDef *hadc, std::function<void()> function) noexcept;
 void setADCCallback(ADC_HandleTypeDef &hadc, std::function<void()> function) noexcept;
+void runADCCallback(ADC_HandleTypeDef *hadc) noexcept;
+void runADCCallback(ADC_HandleTypeDef &hadc) noexcept;
 
 } // namespace halex
-
-#endif // CONFIG_DISABLE_EX_CALLBACK
 
 #endif // CONFIG_DISABLE_MODULE_ADC
 

--- a/adc/class/ADC_DMA.md
+++ b/adc/class/ADC_DMA.md
@@ -103,11 +103,9 @@ ADCn:
 
 ##### ADC_DMA::setCallback(std::function<void()>)
 > ```c++
-> #ifndef CONFIG_DISABLE_EX_CALLBACK
 > void setCallback(
 >     std::function<void()> function
 > ) noexcept;
-> #endif // CONFIG_DISABLE_EX_CALLBACK
 > ```
 > ADC完了時の割り込み関数を設定します
 > ```c++

--- a/adc/function/README.md
+++ b/adc/function/README.md
@@ -19,4 +19,17 @@
 > ```
 > `HAL_ADC_ConvCpltCallback` や `HAL_ADC_ConvHalfCpltCallback` の処理を変更します
 
+##### runADCCallback
+> ```c++
+> void runADCCallback(
+>     ADC_HandleTypeDef *hadc
+> ) noexcept;
+> ```
+> ```c++
+> void runADCCallback(
+>     ADC_HandleTypeDef &hadc
+> ) noexcept;
+> ```
+> `HAL_ADC_ConvCpltCallback` や `HAL_ADC_ConvHalfCpltCallback` の中で呼び出すことで設定されているコールバックの処理を実行できます
+
 [<< 戻る](../README.md)

--- a/general/README.md
+++ b/general/README.md
@@ -1,8 +1,0 @@
-# General
-
-## コンフィグ
-
-> #### CONFIG_DISABLE_EX_CALLBACK
-> コールバック関数を自動で定義されたくない場合に定義してください
-
-[<< 戻る](../README.md)

--- a/i2c/callback.cpp
+++ b/i2c/callback.cpp
@@ -1,7 +1,5 @@
 #ifndef CONFIG_DISABLE_MODULE_I2C
 
-#ifndef CONFIG_DISABLE_EX_CALLBACK
-
 #include "i2c/callback.hpp"
 #include <map>
 #include "util/function.hpp"
@@ -36,57 +34,76 @@ void setI2CErrorCallback(I2C_HandleTypeDef *hi2c, std::function<void()> function
     i2c_error_callback[hi2c] = function;
 }
 
-void setI2CMasterTxCallback(I2C_HandleTypeDef &hi2c, std::function<void()> function) {
+void setI2CMasterTxCallback(I2C_HandleTypeDef &hi2c, std::function<void()> function) noexcept {
     setI2CMasterTxCallback(&hi2c, function);
 }
 
-void setI2CMasterRxCallback(I2C_HandleTypeDef &hi2c, std::function<void()> function) {
+void setI2CMasterRxCallback(I2C_HandleTypeDef &hi2c, std::function<void()> function) noexcept {
     setI2CMasterRxCallback(&hi2c, function);
 }
 
-void setI2CSlaveTxCallback(I2C_HandleTypeDef &hi2c, std::function<void()> function) {
+void setI2CSlaveTxCallback(I2C_HandleTypeDef &hi2c, std::function<void()> function) noexcept {
     setI2CSlaveTxCallback(&hi2c, function);
 }
 
-void setI2CSlaveRxCallback(I2C_HandleTypeDef &hi2c, std::function<void()> function) {
+void setI2CSlaveRxCallback(I2C_HandleTypeDef &hi2c, std::function<void()> function) noexcept {
     setI2CSlaveRxCallback(&hi2c, function);
 }
 
-void setI2CErrorCallback(I2C_HandleTypeDef &hi2c, std::function<void()> function) {
+void setI2CErrorCallback(I2C_HandleTypeDef &hi2c, std::function<void()> function) noexcept {
     setI2CErrorCallback(&hi2c, function);
 }
 
-} // namespace halex
-
-void HAL_I2C_MasterTxCpltCallback(I2C_HandleTypeDef *hi2c) {
+void runI2CMasterTxCallback(I2C_HandleTypeDef *hi2c) noexcept {
     if(halex::map_contains(halex::i2c_master_tx_callback, hi2c)) {
         halex::i2c_master_tx_callback[hi2c]();
     }
 }
 
-void HAL_I2C_MasterRxCpltCallback(I2C_HandleTypeDef *hi2c) {
+void runI2CMasterRxCallback(I2C_HandleTypeDef *hi2c) noexcept {
     if(halex::map_contains(halex::i2c_master_rx_callback, hi2c)) {
         halex::i2c_master_rx_callback[hi2c]();
     }
 }
 
-void HAL_I2C_SlaveTxCpltCallback(I2C_HandleTypeDef *hi2c) {
+void runI2CSlaveTxCallback(I2C_HandleTypeDef *hi2c) noexcept {
     if(halex::map_contains(halex::i2c_slave_tx_callback, hi2c)) {
         halex::i2c_slave_tx_callback[hi2c]();
     }
 }
 
-void HAL_I2C_SlaveRxCpltCallback(I2C_HandleTypeDef *hi2c) {
+void runI2CSlaveRxCallback(I2C_HandleTypeDef *hi2c) noexcept {
     if(halex::map_contains(halex::i2c_slave_rx_callback, hi2c)) {
         halex::i2c_slave_rx_callback[hi2c]();
     }
 }
 
-void HAL_I2C_ErrorCallback(I2C_HandleTypeDef *hi2c) {
+void runI2CErrorCallback(I2C_HandleTypeDef *hi2c) noexcept {
     if(halex::map_contains(halex::i2c_error_callback, hi2c)) {
         halex::i2c_error_callback[hi2c]();
     }
 }
-#endif // CONFIG_DISABLE_EX_CALLBACK
+
+void runI2CMasterTxCallback(I2C_HandleTypeDef &hi2c) noexcept {
+    runI2CMasterTxCallback(&hi2c);
+}
+
+void runI2CMasterRxCallback(I2C_HandleTypeDef &hi2c) noexcept {
+    runI2CMasterRxCallback(&hi2c);
+}
+
+void runI2CSlaveTxCallback(I2C_HandleTypeDef &hi2c) noexcept {
+    runI2CSlaveTxCallback(&hi2c);
+}
+
+void runI2CSlaveRxCallback(I2C_HandleTypeDef &hi2c) noexcept {
+    runI2CSlaveRxCallback(&hi2c);
+}
+
+void runI2CErrorCallback(I2C_HandleTypeDef &hi2c) noexcept {
+    runI2CErrorCallback(&hi2c);
+}
+
+} // namespace halex
 
 #endif // CONFIG_DISABLE_MODULE_I2C

--- a/i2c/callback.hpp
+++ b/i2c/callback.hpp
@@ -8,18 +8,26 @@
 
 namespace halex {
 
-#ifndef CONFIG_DISABLE_EX_CALLBACK
-void setI2CMasterTxCallback(I2C_HandleTypeDef *hi2c, std::function<void()> function);
-void setI2CMasterRxCallback(I2C_HandleTypeDef *hi2c, std::function<void()> function);
-void setI2CSlaveTxCallback(I2C_HandleTypeDef *hi2c, std::function<void()> function);
-void setI2CSlaveRxCallback(I2C_HandleTypeDef *hi2c, std::function<void()> function);
-void setI2CErrorCallback(I2C_HandleTypeDef *hi2c, std::function<void()> function);
-void setI2CMasterTxCallback(I2C_HandleTypeDef &hi2c, std::function<void()> function);
-void setI2CMasterRxCallback(I2C_HandleTypeDef &hi2c, std::function<void()> function);
-void setI2CSlaveTxCallback(I2C_HandleTypeDef &hi2c, std::function<void()> function);
-void setI2CSlaveRxCallback(I2C_HandleTypeDef &hi2c, std::function<void()> function);
-void setI2CErrorCallback(I2C_HandleTypeDef &hi2c, std::function<void()> function);
-#endif // CONFIG_DISABLE_EX_CALLBACK
+void setI2CMasterTxCallback(I2C_HandleTypeDef *hi2c, std::function<void()> function) noexcept;
+void setI2CMasterRxCallback(I2C_HandleTypeDef *hi2c, std::function<void()> function) noexcept;
+void setI2CSlaveTxCallback(I2C_HandleTypeDef *hi2c, std::function<void()> function) noexcept;
+void setI2CSlaveRxCallback(I2C_HandleTypeDef *hi2c, std::function<void()> function) noexcept;
+void setI2CErrorCallback(I2C_HandleTypeDef *hi2c, std::function<void()> function) noexcept;
+void setI2CMasterTxCallback(I2C_HandleTypeDef &hi2c, std::function<void()> function) noexcept;
+void setI2CMasterRxCallback(I2C_HandleTypeDef &hi2c, std::function<void()> function) noexcept;
+void setI2CSlaveTxCallback(I2C_HandleTypeDef &hi2c, std::function<void()> function) noexcept;
+void setI2CSlaveRxCallback(I2C_HandleTypeDef &hi2c, std::function<void()> function) noexcept;
+void setI2CErrorCallback(I2C_HandleTypeDef &hi2c) noexcept;
+void runI2CMasterTxCallback(I2C_HandleTypeDef *hi2c) noexcept;
+void runI2CMasterRxCallback(I2C_HandleTypeDef *hi2c) noexcept;
+void runI2CSlaveTxCallback(I2C_HandleTypeDef *hi2c) noexcept;
+void runI2CSlaveRxCallback(I2C_HandleTypeDef *hi2c) noexcept;
+void runI2CErrorCallback(I2C_HandleTypeDef *hi2c) noexcept;
+void runI2CMasterTxCallback(I2C_HandleTypeDef &hi2c) noexcept;
+void runI2CMasterRxCallback(I2C_HandleTypeDef &hi2c) noexcept;
+void runI2CSlaveTxCallback(I2C_HandleTypeDef &hi2c) noexcept;
+void runI2CSlaveRxCallback(I2C_HandleTypeDef &hi2c) noexcept;
+void runI2CErrorCallback(I2C_HandleTypeDef &hi2c) noexcept;
 
 } // namespace halex
 

--- a/i2c/class/I2C_Master_DMA.md
+++ b/i2c/class/I2C_Master_DMA.md
@@ -88,11 +88,9 @@ T: 送受信するデータ型
 
 ##### I2C_Master_DMA::setTxCallback(std::function<void()>)
 > ```c++
-> #ifndef CONFIG_DISABLE_EX_CALLBACK
 > void setTxCallback(
 >     std::function<void()> function
 > ) noexcept;
-> #endif // CONFIG_DISABLE_EX_CALLBACK
 > ```
 > 送信完了時の割り込み関数を設定します  
 > ```c++
@@ -104,11 +102,9 @@ T: 送受信するデータ型
 
 ##### I2C_Master_DMA::setRxCallback(std::function<void()>)
 > ```c++
-> #ifndef CONFIG_DISABLE_EX_CALLBACK
 > void setRxCallback(
 >     std::function<void()> function
 > ) noexcept;
-> #endif // CONFIG_DISABLE_EX_CALLBACK
 > ```
 > 受信完了時の割り込み関数を設定します
 > ```c++
@@ -120,11 +116,9 @@ T: 送受信するデータ型
 
 ##### I2C_Master_DMA::setErrorCallback(std::function<void()>)
 > ```c++
-> #ifndef CONFIG_DISABLE_EX_CALLBACK
 > void setErrorCallback(
 >     std::function<void()> function
 > ) noexcept;
-> #endif // CONFIG_DISABLE_EX_CALLBACK
 > ```
 > エラー取得時の割り込み関数を設定します
 > ```c++

--- a/i2c/class/I2C_Master_IT.md
+++ b/i2c/class/I2C_Master_IT.md
@@ -86,11 +86,9 @@ T: 送受信するデータ型
 
 ##### I2C_Master_IT::setTxCallback(std::function<void()>)
 > ```c++
-> #ifndef CONFIG_DISABLE_EX_CALLBACK
 > void setTxCallback(
 >     std::function<void()> function
 > ) noexcept;
-> #endif // CONFIG_DISABLE_EX_CALLBACK
 > ```
 > 送信完了時の割り込み関数を設定します  
 > ```c++
@@ -102,11 +100,9 @@ T: 送受信するデータ型
 
 ##### I2C_Master_IT::setRxCallback(std::function<void()>)
 > ```c++
-> #ifndef CONFIG_DISABLE_EX_CALLBACK
 > void setRxCallback(
 >     std::function<void()> function
 > ) noexcept;
-> #endif // CONFIG_DISABLE_EX_CALLBACK
 > ```
 > 受信完了時の割り込み関数を設定します
 > ```c++
@@ -118,11 +114,9 @@ T: 送受信するデータ型
 
 ##### I2C_Master_IT::setErrorCallback(std::function<void()>)
 > ```c++
-> #ifndef CONFIG_DISABLE_EX_CALLBACK
 > void setErrorCallback(
 >     std::function<void()> function
 > ) noexcept;
-> #endif // CONFIG_DISABLE_EX_CALLBACK
 > ```
 > エラー取得時の割り込み関数を設定します
 > ```c++

--- a/i2c/class/I2C_Slave_DMA.md
+++ b/i2c/class/I2C_Slave_DMA.md
@@ -114,11 +114,9 @@ T: 送受信するデータ型
 
 ##### I2C_Slave_DMA::setTxCallback(std::function<void()>)
 > ```c++
-> #ifndef CONFIG_DISABLE_EX_CALLBACK
 > void setTxCallback(
 >     std::function<void()> function
 > ) noexcept;
-> #endif // CONFIG_DISABLE_EX_CALLBACK
 > ```
 > 送信完了時の割り込み関数を設定します  
 > ```c++
@@ -130,11 +128,9 @@ T: 送受信するデータ型
 
 ##### I2C_Slave_DMA::setRxCallback(std::function<void()>)
 > ```c++
-> #ifndef CONFIG_DISABLE_EX_CALLBACK
 > void setRxCallback(
 >     std::function<void()> function
 > ) noexcept;
-> #endif // CONFIG_DISABLE_EX_CALLBACK
 > ```
 > 受信完了時の割り込み関数を設定します
 > ```c++
@@ -146,11 +142,9 @@ T: 送受信するデータ型
 
 ##### I2C_Slave_DMA::setErrorCallback(std::function<void()>)
 > ```c++
-> #ifndef CONFIG_DISABLE_EX_CALLBACK
 > void setErrorCallback(
 >     std::function<void()> function
 > ) noexcept;
-> #endif // CONFIG_DISABLE_EX_CALLBACK
 > ```
 > エラー取得時の割り込み関数を設定します
 > ```c++

--- a/i2c/class/I2C_Slave_IT.md
+++ b/i2c/class/I2C_Slave_IT.md
@@ -115,11 +115,9 @@ T: 送受信するデータ型
 
 ##### I2C_Slave_IT::setTxCallback(std::function<void()>)
 > ```c++
-> #ifndef CONFIG_DISABLE_EX_CALLBACK
 > void setTxCallback(
 >     std::function<void()> function
 > ) noexcept;
-> #endif // CONFIG_DISABLE_EX_CALLBACK
 > ```
 > 送信完了時の割り込み関数を設定します  
 > ```c++
@@ -131,11 +129,9 @@ T: 送受信するデータ型
 
 ##### I2C_Slave_IT::setRxCallback(std::function<void()>)
 > ```c++
-> #ifndef CONFIG_DISABLE_EX_CALLBACK
 > void setRxCallback(
 >     std::function<void()> function
 > ) noexcept;
-> #endif // CONFIG_DISABLE_EX_CALLBACK
 > ```
 > 受信完了時の割り込み関数を設定します
 > ```c++
@@ -147,11 +143,9 @@ T: 送受信するデータ型
 
 ##### I2C_Slave_IT::setErrorCallback(std::function<void()>)
 > ```c++
-> #ifndef CONFIG_DISABLE_EX_CALLBACK
 > void setErrorCallback(
 >     std::function<void()> function
 > ) noexcept;
-> #endif // CONFIG_DISABLE_EX_CALLBACK
 > ```
 > エラー取得時の割り込み関数を設定します
 > ```c++

--- a/i2c/i2c_master_dma.hpp
+++ b/i2c/i2c_master_dma.hpp
@@ -40,7 +40,6 @@ public:
         return i2cMasterReceive_DMA(hi2c, target, data);
     }
 
-#ifndef CONFIG_DISABLE_EX_CALLBACK
     void setTxCallback(std::function<void()> function) noexcept {
         setI2CMasterTxCallback(hi2c, function);
     }
@@ -52,7 +51,6 @@ public:
     void setErrorCallback(std::function<void()> function) noexcept {
         setI2CErrorCallback(hi2c, function);
     }
-#endif // CONFIG_DISABLE_EX_CALLBACK
 };
 
 } // namespace halex

--- a/i2c/i2c_master_it.hpp
+++ b/i2c/i2c_master_it.hpp
@@ -38,7 +38,6 @@ public:
         return i2cMasterReceive_IT(hi2c, target, data);
     }
 
-#ifndef CONFIG_DISABLE_EX_CALLBACK
     void setTxCallback(std::function<void()> function) noexcept {
         setI2CMasterTxCallback(hi2c, function);
     }
@@ -50,7 +49,6 @@ public:
     void setErrorCallback(std::function<void()> function) noexcept {
         setI2CErrorCallback(hi2c, function);
     }
-#endif // CONFIG_DISABLE_EX_CALLBACK
 };
 
 } // namespace halex

--- a/i2c/i2c_slave_dma.hpp
+++ b/i2c/i2c_slave_dma.hpp
@@ -52,7 +52,6 @@ public:
         return i2cSlaveReceive_DMA(hi2c, data);
     }
 
-#ifndef CONFIG_DISABLE_EX_CALLBACK
     void setTxCallback(std::function<void()> function) noexcept {
         setI2CSlaveTxCallback(hi2c, function);
     }
@@ -64,7 +63,6 @@ public:
     void setErrorCallback(std::function<void()> function) noexcept {
         setI2CErrorCallback(hi2c, function);
     }
-#endif // CONFIG_DISABLE_EX_CALLBACK
 };
 
 } // namespace halex

--- a/i2c/i2c_slave_it.hpp
+++ b/i2c/i2c_slave_it.hpp
@@ -51,7 +51,6 @@ public:
         return i2cSlaveReceive_IT(hi2c, data);
     }
 
-#ifndef CONFIG_DISABLE_EX_CALLBACK
     void setTxCallback(std::function<void()> function) noexcept {
         setI2CSlaveTxCallback(hi2c, function);
     }
@@ -63,7 +62,6 @@ public:
     void setErrorCallback(std::function<void()> function) noexcept {
         setI2CErrorCallback(hi2c, function);
     }
-#endif // CONFIG_DISABLE_EX_CALLBACK
 };
 
 } // namespace halex

--- a/tim/callback.cpp
+++ b/tim/callback.cpp
@@ -1,7 +1,5 @@
 #ifndef CONFIG_DISABLE_MODULE_TIM
 
-#ifndef CONFIG_DISABLE_EX_CALLBACK
-
 #include "tim/callback.hpp"
 #include <map>
 #include "util/function.hpp"
@@ -20,18 +18,16 @@ void setTIMPeriodElapsedCallback(TIM_HandleTypeDef &htim, std::function<void()> 
     setTIMPeriodElapsedCallback(&htim, function);
 }
 
-} // namespace halex
-
-#ifdef CONFIG_TIM_USE_HALF_CALLBACK
-void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim) {
-#else  // CONFIG_TIM_USE_HALF_CALLBACK
-void HAL_TIM_PeriodElapsedHalfCpltCallback(TIM_HandleTypeDef *htim) {
-#endif // CONFIG_TIM_USE_HALF_CALLBACK
+void runTIMPeriodElapsedCallback(TIM_HandleTypeDef *htim) noexcept {
     if(halex::map_contains(halex::tim_period_elapsed_callback, htim)) {
         halex::tim_period_elapsed_callback[htim]();
     }
 }
 
-#endif // CONFIG_DISABLE_EX_CALLBACK
+void runTIMPeriodElapsedCallback(TIM_HandleTypeDef &htim) noexcept {
+    runTIMPeriodElapsedCallback(&htim);
+}
+
+} // namespace halex
 
 #endif // CONFIG_DISABLE_MODULE_TIM

--- a/tim/callback.hpp
+++ b/tim/callback.hpp
@@ -3,8 +3,6 @@
 
 #ifndef CONFIG_DISABLE_MODULE_TIM
 
-#ifndef CONFIG_DISABLE_EX_CALLBACK
-
 #include <functional>
 #include "tim.h"
 
@@ -12,10 +10,10 @@ namespace halex {
 
 void setTIMPeriodElapsedCallback(TIM_HandleTypeDef *htim, std::function<void()> function) noexcept;
 void setTIMPeriodElapsedCallback(TIM_HandleTypeDef &htim, std::function<void()> function) noexcept;
+void runTIMPeriodElapsedCallback(TIM_HandleTypeDef *htim) noexcept;
+void runTIMPeriodElapsedCallback(TIM_HandleTypeDef &htim) noexcept;
 
 } // namespace halex
-
-#endif // CONFIG_DISABLE_EX_CALLBACK
 
 #endif // CONFIG_DISABLE_MODULE_TIM
 

--- a/tim/class/TimerInterrupt.md
+++ b/tim/class/TimerInterrupt.md
@@ -90,11 +90,9 @@ NVIC Settings:
 
 ##### TimerInterrupt::setCallback(std::function<void()>)
 > ```c++
-> #ifndef CONFIG_DISABLE_EX_CALLBACK
 > void setCallback(
 >     std::function<void()> function
 > ) noexcept;
-> #endif // CONFIG_DISABLE_EX_CALLBACK
 > ```
 > タイマ割り込みの処理を設定します
 > ```c++

--- a/tim/function/README.md
+++ b/tim/function/README.md
@@ -23,4 +23,17 @@
 > ```
 > `HAL_TIM_PeriodElapsedCallback` や `HAL_TIM_PeriodElapsedHalfCpltCallback` の処理を変更します
 
+##### runTIMPeriodElapsedCallback
+> ```c++
+> void runTIMPeriodElapsedCallback(
+>     TIM_HandleTypeDef *htim
+> ) noexcept;
+> ```
+> ```c++
+> void runTIMPeriodElapsedCallback(
+>     TIM_HandleTypeDef &htim
+> ) noexcept;
+> ```
+> `HAL_TIM_PeriodElapsedCallback` や `HAL_TIM_PeriodElapsedHalfCpltCallback` の中で呼び出すことで設定されているコールバックの処理を実行できます
+
 [<< 戻る](../README.md)

--- a/tim/timer_interrupt.cpp
+++ b/tim/timer_interrupt.cpp
@@ -42,11 +42,9 @@ void TimerInterrupt::resetCount() noexcept {
     setCount(0);
 }
 
-#ifndef CONFIG_DISABLE_EX_CALLBACK
 void TimerInterrupt::setCallback(std::function<void()> function) noexcept {
     setTIMPeriodElapsedCallback(htim, function);
 }
-#endif // CONFIG_DISABLE_EX_CALLBACK
 
 } // namespace halex
 

--- a/tim/timer_interrupt.hpp
+++ b/tim/timer_interrupt.hpp
@@ -20,9 +20,7 @@ public:
     void stop() noexcept;
     void setCount(uint32_t count) noexcept;
     void resetCount() noexcept;
-#ifndef CONFIG_DISABLE_EX_CALLBACK
     void setCallback(std::function<void()> function) noexcept;
-#endif // CONFIG_DISABLE_EX_CALLBACK
 };
 
 } // namespace halex

--- a/uart/README.md
+++ b/uart/README.md
@@ -6,9 +6,6 @@
 > UART モジュールの無効化  
 > 定義することでコンパイルされなくなります
 
-> ##### CONFIG_USE_HALF_CALLBACK_UART
-> UARTのコールバック関数をハーフに変更します
-
 ## 関数
 - [Transmit](function/README.md#transmit)
   - [uartTransmit](function/README.md#uarttransmit)

--- a/uart/callback.cpp
+++ b/uart/callback.cpp
@@ -1,7 +1,5 @@
 #ifndef CONFIG_DISABLE_MODULE_UART
 
-#ifndef CONFIG_DISABLE_EX_CALLBACK
-
 #include "uart/callback.hpp"
 #include <map>
 #include "util/function.hpp"
@@ -38,33 +36,36 @@ void setUARTErrorCallback(UART_HandleTypeDef &huart, std::function<void()> funct
     setUARTErrorCallback(&huart, function);
 }
 
-} // namespace halex
-
-#ifdef CONFIG_USE_HALF_CALLBACK_UART
-void HAL_UART_TxHalfCpltCallback(UART_HandleTypeDef *huart) {
-#else  // CONFIG_USE_HALF_CALLBACK_UART
-void HAL_UART_TxCpltCallback(UART_HandleTypeDef *huart) {
-#endif // CONFIG_USE_HALF_CALLBACK_UART
+void runUARTTxCallback(UART_HandleTypeDef *huart) {
     if(halex::map_contains(halex::uart_tx_callback, huart)) {
         halex::uart_tx_callback[huart]();
     }
 }
 
-#ifdef CONFIG_USE_HALF_CALLBACK_UART
-void HAL_UART_RxHalfCpltCallback(UART_HandleTypeDef *huart) {
-#else  // CONFIG_USE_HALF_CALLBACK_UART
-void HAL_UART_RxCpltCallback(UART_HandleTypeDef *huart) {
-#endif // CONFIG_USE_HALF_CALLBACK_UART
+void runUARTRxCallback(UART_HandleTypeDef *huart) {
     if(halex::map_contains(halex::uart_rx_callback, huart)) {
         halex::uart_rx_callback[huart]();
     }
 }
 
-void HAL_UART_ErrorCallback(UART_HandleTypeDef *huart) {
+void runUARTErrorCallback(UART_HandleTypeDef *huart) {
     if(halex::map_contains(halex::uart_error_callback, huart)) {
         halex::uart_error_callback[huart]();
     }
 }
-#endif // CONFIG_DISABLE_EX_CALLBACK
+
+void runUARTTxCallback(UART_HandleTypeDef &huart) {
+    runUARTTxCallback(&huart);
+}
+
+void runUARTRxCallback(UART_HandleTypeDef &huart) {
+    runUARTRxCallback(&huart);
+}
+
+void runUARTErrorCallback(UART_HandleTypeDef &huart) {
+    runUARTErrorCallback(&huart);
+}
+
+} // namespace halex
 
 #endif // CONFIG_DISABLE_MODULE_UART

--- a/uart/callback.hpp
+++ b/uart/callback.hpp
@@ -8,14 +8,18 @@
 
 namespace halex {
 
-#ifndef CONFIG_DISABLE_EX_CALLBACK
 void setUARTTxCallback(UART_HandleTypeDef *huart, std::function<void()> function);
 void setUARTRxCallback(UART_HandleTypeDef *huart, std::function<void()> function);
 void setUARTErrorCallback(UART_HandleTypeDef *huart, std::function<void()> function);
 void setUARTTxCallback(UART_HandleTypeDef &huart, std::function<void()> function);
 void setUARTRxCallback(UART_HandleTypeDef &huart, std::function<void()> function);
 void setUARTErrorCallback(UART_HandleTypeDef &huart, std::function<void()> function);
-#endif // CONFIG_DISABLE_EX_CALLBACK
+void runUARTTxCallback(UART_HandleTypeDef *huart);
+void runUARTRxCallback(UART_HandleTypeDef *huart);
+void runUARTErrorCallback(UART_HandleTypeDef *huart);
+void runUARTTxCallback(UART_HandleTypeDef &huart);
+void runUARTRxCallback(UART_HandleTypeDef &huart);
+void runUARTErrorCallback(UART_HandleTypeDef &huart);
 
 } // namespace halex
 

--- a/uart/class/UART_DMA.md
+++ b/uart/class/UART_DMA.md
@@ -116,11 +116,9 @@ T: 送受信するデータ型
 
 ##### UART_DMA::setTxCallback(std::function<void()>)
 > ```c++
-> #ifndef CONFIG_DISABLE_EX_CALLBACK
 > void setTxCallback(
 >     std::function<void()> function
 > ) noexcept;
-> #endif // CONFIG_DISABLE_EX_CALLBACK
 > ```
 > 送信完了時の割り込み関数を設定します  
 > ```c++
@@ -132,11 +130,9 @@ T: 送受信するデータ型
 
 ##### UART_DMA::setRxCallback(std::function<void()>)
 > ```c++
-> #ifndef CONFIG_DISABLE_EX_CALLBACK
 > void setRxCallback(
 >     std::function<void()> function
 > ) noexcept;
-> #endif // CONFIG_DISABLE_EX_CALLBACK
 > ```
 > 受信完了時の割り込み関数を設定します  
 > ```c++
@@ -148,11 +144,9 @@ T: 送受信するデータ型
 
 ##### UART_DMA::setErrorCallback(std::function<void()>)
 > ```c++
-> #ifndef CONFIG_DISABLE_EX_CALLBACK
 > void setErrorCallback(
 >     std::function<void()> function
 > ) noexcept;
-> #endif // CONFIG_DISABLE_EX_CALLBACK
 > ```
 > エラー取得時の割り込み関数を設定します  
 > ```c++

--- a/uart/class/UART_IT.md
+++ b/uart/class/UART_IT.md
@@ -79,11 +79,9 @@ T: 送受信するデータ型
 
 ##### UART_IT::setTxCallback(std::function<void()>)
 > ```c++
-> #ifndef CONFIG_DISABLE_EX_CALLBACK
 > void setTxCallback(
 >     std::function<void()> function
 > ) noexcept;
-> #endif // CONFIG_DISABLE_EX_CALLBACK
 > ```
 > 送信完了時の割り込み関数を設定します  
 > ```c++
@@ -95,11 +93,9 @@ T: 送受信するデータ型
 
 ##### UART_IT::setRxCallback(std::function<void()>)
 > ```c++
-> #ifndef CONFIG_DISABLE_EX_CALLBACK
 > void setRxCallback(
 >     std::function<void()> function
 > ) noexcept;
-> #endif // CONFIG_DISABLE_EX_CALLBACK
 > ```
 > 受信完了時の割り込み関数を設定します  
 > ```c++
@@ -111,11 +107,9 @@ T: 送受信するデータ型
 
 ##### UART_IT::setErrorCallback(std::function<void()>)
 > ```c++
-> #ifndef CONFIG_DISABLE_EX_CALLBACK
 > void setErrorCallback(
 >     std::function<void()> function
 > ) noexcept;
-> #endif // CONFIG_DISABLE_EX_CALLBACK
 > ```
 > エラー取得時の割り込み関数を設定します  
 > ```c++

--- a/uart/class/UART_Logger_IT.md
+++ b/uart/class/UART_Logger_IT.md
@@ -75,18 +75,4 @@ USARTn:
 > logger.println("HelloWorld");
 > ```
 
-##### UART_Logger_IT::itTxCallback(UART_HandleTypeDef*)
-> ```c++
-> #ifdef CONFIG_DISABLE_EX_CALLBACK
->     void itTxCallback(UART_HandleTypeDef *huart) noexcept;
-> #endif // CONFIG_DISABLE_EX_CALLBACK
-> ```
-> `CONFIG_DISABLE_EX_CALLBACK` を定義した時のみ定義されます
-> ```c++
-> // 例
-> void HAL_UART_TxCpltCallback(UART_HandleTypeDef *huart) {
->     logger.itTxCallback(huart);
-> }
-> ```
-
 [<< 戻る](../README.md)

--- a/uart/function/README.md
+++ b/uart/function/README.md
@@ -173,4 +173,43 @@
 > ```
 > `HAL_UART_ErrorCallback` の処理を変更します
 
+##### runUARTTxCallback
+> ```c++
+> void runUARTTxCallback(
+>     UART_HandleTypeDef *huart
+> );
+> ```
+> ```c++
+> void runUARTTxCallback(
+>     UART_HandleTypeDef &huart
+> );
+> ```
+> `HAL_UART_TxCpltCallback` や `HAL_UART_TxHalfCpltCallback` の中で呼び出すことで設定されているコールバックの処理を実行できます
+
+##### runUARTRxCallback
+> ```c++
+> void runUARTRxCallback(
+>     UART_HandleTypeDef *huart
+> );
+> ```
+> ```c++
+> void runUARTRxCallback(
+>     UART_HandleTypeDef &huart
+> );
+> ```
+> `HAL_UART_RxCpltCallback` や `HAL_UART_RxHalfCpltCallback` の中で呼び出すことで設定されているコールバックの処理を実行できます
+
+##### runUARTErrorCallback
+> ```c++
+> void runUARTErrorCallback(
+>     UART_HandleTypeDef *huart
+> );
+> ```
+> ```c++
+> void runUARTErrorCallback(
+>     UART_HandleTypeDef &huart
+> );
+> ```
+> `HAL_UART_ErrorCallback` の中で呼び出すことで設定されているコールバックの処理を実行できます
+
 [<< 戻る](../README.md)

--- a/uart/uart_dma.hpp
+++ b/uart/uart_dma.hpp
@@ -46,7 +46,6 @@ public:
         return HAL_UART_DMAStop(huart);
     }
 
-#ifndef CONFIG_DISABLE_EX_CALLBACK
     void setTxCallback(std::function<void()> function) noexcept {
         setUARTTxCallback(huart, function);
     }
@@ -58,7 +57,6 @@ public:
     void setErrorCallback(std::function<void()> function) noexcept {
         setErrorCallback(huart, function);
     }
-#endif // CONFIG_DISABLE_EX_CALLBACK
 };
 
 } // namespace halex

--- a/uart/uart_it.hpp
+++ b/uart/uart_it.hpp
@@ -33,7 +33,6 @@ public:
         return uartReceive_IT(huart, data);
     }
 
-#ifndef CONFIG_DISABLE_EX_CALLBACK
     void setTxCallback(std::function<void()> function) noexcept {
         setUARTTxCallback(huart, function);
     }
@@ -45,7 +44,6 @@ public:
     void setErrorCallback(std::function<void()> function) noexcept {
         setErrorCallback(huart, function);
     }
-#endif // CONFIG_DISABLE_EX_CALLBACK
 };
 
 } // namespace halex

--- a/uart/uart_logger_it.cpp
+++ b/uart/uart_logger_it.cpp
@@ -8,13 +8,11 @@ namespace halex {
 UART_Logger_IT::UART_Logger_IT() {}
 
 UART_Logger_IT::UART_Logger_IT(UART_HandleTypeDef *huart): huart(huart) {
-#ifndef CONFIG_DISABLE_EX_CALLBACK
     setUARTTxCallback(huart, [this]{ itTxCallback(); });
-#endif
 }
 
 UART_Logger_IT::UART_Logger_IT(UART_HandleTypeDef &huart): UART_Logger_IT(&huart) {
-
+d
 }
 
 void UART_Logger_IT::checkBuffer() noexcept {
@@ -23,12 +21,7 @@ void UART_Logger_IT::checkBuffer() noexcept {
     HAL_UART_Transmit_IT(huart, (uint8_t *) front.c_str(), front.size());
 }
 
-#ifndef CONFIG_DISABLE_EX_CALLBACK
 void UART_Logger_IT::itTxCallback() noexcept {
-#else
-void UART_Logger_IT::itTxCallback(UART_HandleTypeDef *huart) noexcept {
-    if(this->huart != huart) return;
-#endif // CONFIG_DISABLE_EX_CALLBACK
     if (buffer.empty()) {
         isBusy = false;
     } else {

--- a/uart/uart_logger_it.hpp
+++ b/uart/uart_logger_it.hpp
@@ -15,10 +15,7 @@ private:
     std::queue<std::string> buffer;
     bool isBusy = false;
     void checkBuffer() noexcept;
-
-#ifndef CONFIG_DISABLE_EX_CALLBACK
     void itTxCallback() noexcept;
-#endif // CONFIG_DISABLE_EX_CALLBACK
 public:
     UART_Logger_IT();
     UART_Logger_IT(UART_HandleTypeDef *huart);
@@ -27,10 +24,6 @@ public:
     void print(const char* text) noexcept;
     void println(std::string text) noexcept;
     void println(const char* text) noexcept;
-
-#ifdef CONFIG_DISABLE_EX_CALLBACK
-    void itTxCallback(UART_HandleTypeDef *huart) noexcept;
-#endif // CONFIG_DISABLE_EX_CALLBACK
 };
 
 } // namespace halex


### PR DESCRIPTION
# 方針
- 自動で定義されていたコールバック関数をユーザーに定義させ、halex::runXXXCallback 関数を呼び出すことでコールバック処理を実行するようにした
- CONFIG_DISABLE_EX_CALLBACK や CONFIG_USE_HALF_CALLBACK_XXX を削除