### PR TITLE
perf(encoder): 不要な処理を削除

### DIFF
--- a/tim/encoder.cpp
+++ b/tim/encoder.cpp
@@ -16,24 +16,17 @@ Encoder::Encoder(TIM_HandleTypeDef &htim): Encoder(&htim) {
 
 void Encoder::start() noexcept {
     __HAL_TIM_SET_COUNTER(htim , 0);
-    __HAL_TIM_CLEAR_FLAG(htim, TIM_FLAG_UPDATE);
-    if(!isStart) {
-        HAL_TIM_Encoder_Start(htim, TIM_CHANNEL_ALL);
-        isStart = true;
-    }
+    lastRawCount = 0;
+    rawCount = 0;
+    HAL_TIM_Encoder_Start(htim, TIM_CHANNEL_ALL);
 }
 
 void Encoder::stop() noexcept {
-    if(isStart) {
-        HAL_TIM_Encoder_Stop(htim, TIM_CHANNEL_ALL);
-        isStart = false;
-    }
+    HAL_TIM_Encoder_Stop(htim, TIM_CHANNEL_ALL);
     __HAL_TIM_SET_COUNTER(htim , 0);
-    __HAL_TIM_CLEAR_FLAG(htim, TIM_FLAG_UPDATE);
 }
 
 void Encoder::update() noexcept {
-    if(!isStart) return;
     lastRawCount = rawCount;
     rawCount = __HAL_TIM_GET_COUNTER(htim);
     count += rawCount - lastRawCount;
@@ -49,7 +42,6 @@ int32_t Encoder::getCount() const noexcept {
 }
 
 void Encoder::setCount(int32_t count) noexcept {
-    __HAL_TIM_CLEAR_FLAG(htim, TIM_FLAG_UPDATE);
     this->count = count;
 }
 

--- a/tim/encoder.hpp
+++ b/tim/encoder.hpp
@@ -10,7 +10,6 @@ namespace halex {
 class Encoder {
 private:
     TIM_HandleTypeDef *htim;
-    bool isStart = false;
     uint16_t lastRawCount = 0;
     uint16_t rawCount = 0;
     int32_t count = 0;


### PR DESCRIPTION
- フラグを使わなくなったので ` __HAL_TIM_CLEAR_FLAG(htim, TIM_FLAG_UPDATE);` を削除
- isStart による判定を削除
- 一度 stop して start しても前回のrawCountを引き継いでしまう問題を修正